### PR TITLE
Hid section pages from search results

### DIFF
--- a/content/ja/docs/FAQ/Business/_index.md
+++ b/content/ja/docs/FAQ/Business/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Business"
 linkTitle: "Business"
+exclude_search: true
 description: >
   FAQ Business 
 ---

--- a/content/ja/docs/FAQ/Technology/_index.md
+++ b/content/ja/docs/FAQ/Technology/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Technology"
 linkTitle: "Technology"
+exclude_search: true
 description: >
   FAQ Technology 
 ---

--- a/content/ja/docs/FAQ/_index.md
+++ b/content/ja/docs/FAQ/_index.md
@@ -2,6 +2,7 @@
 title: "FAQ"
 linkTitle: "FAQ"
 weight: 1
+exclude_search: true
 description: >
   Technical and Business FAQ 
 ---

--- a/content/ja/docs/_index.md
+++ b/content/ja/docs/_index.md
@@ -3,6 +3,7 @@
 title: ""
 linkTitle: "ドキュメンテーション"
 weight: 20
+exclude_search: true
 menu:
   main:
     weight: 20

--- a/content/ja/docs/developers/_index.md
+++ b/content/ja/docs/developers/_index.md
@@ -2,6 +2,7 @@
 title: "Cordaの開発"
 linkTitle: "Cordaの開発"
 weight: 1
+exclude_search: true
 description: >
   Corda development
 ---

--- a/content/ja/docs/developers/cordapp_development/_index.md
+++ b/content/ja/docs/developers/cordapp_development/_index.md
@@ -2,6 +2,7 @@
 title: "CorDapp開発"
 linkTitle: "CorDapp開発"
 weight: 2
+exclude_search: true
 description: >
   CorDapp development
 ---

--- a/content/ja/docs/developers/design/_index.md
+++ b/content/ja/docs/developers/design/_index.md
@@ -2,6 +2,7 @@
 title: "Architecture Design"
 linkTitle: "Architecture Design"
 weight: 3
+exclude_search: true
 description: >
   Corda architectural design
 ---

--- a/content/ja/docs/developers/getting_started/_index.md
+++ b/content/ja/docs/developers/getting_started/_index.md
@@ -2,6 +2,7 @@
 title: "Getting Started"
 linkTitle: "Getting Started"
 weight: 4
+exclude_search: true
 description: >
   Getting Started
 ---

--- a/content/ja/docs/developers/network_operations/_index.md
+++ b/content/ja/docs/developers/network_operations/_index.md
@@ -2,6 +2,7 @@
 title: "Network Operations"
 linkTitle: "Network Operations"
 weight: 1
+exclude_search: true
 description: >
   Corda Network Operations
 ---

--- a/content/ja/docs/developers/node_operations/_index.md
+++ b/content/ja/docs/developers/node_operations/_index.md
@@ -2,6 +2,7 @@
 title: "Node operations"
 linkTitle: "Node operations"
 weight: 1
+exclude_search: true
 description: >
   Node operations
 ---

--- a/content/ja/docs/developers/performance/_index.md
+++ b/content/ja/docs/developers/performance/_index.md
@@ -2,6 +2,7 @@
 title: "Performance"
 linkTitle: "Performance"
 weight: 1
+exclude_search: true
 description: >
   Corda performance
 ---

--- a/content/ja/docs/developers/samples/_index.md
+++ b/content/ja/docs/developers/samples/_index.md
@@ -2,6 +2,7 @@
 title: "Samples"
 linkTitle: "Samples"
 weight: 1
+exclude_search: true
 description: >
   Corda samples
 ---

--- a/content/ja/docs/release_notes/_index.md
+++ b/content/ja/docs/release_notes/_index.md
@@ -2,6 +2,7 @@
 title: "Release Notes"
 linkTitle: "Release Notes"
 weight: 1
+exclude_search: true
 description: >
   Release notes related info 
 ---

--- a/content/ja/docs/understanding_corda/_index.md
+++ b/content/ja/docs/understanding_corda/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Cordaの理解"
 linkTitle: "Cordaの理解"
+exclude_search: true
 description: >
   Articles about Corda functionalities 
 ---

--- a/content/ja/docs/understanding_corda/general_concepts/_index.md
+++ b/content/ja/docs/understanding_corda/general_concepts/_index.md
@@ -2,6 +2,7 @@
 title: "Corda General Concepts"
 linkTitle: "Corda General Concepts"
 weight: 1
+exclude_search: true
 description: >
   Corda general concepts
 ---


### PR DESCRIPTION
Excluding section pages from search results by setting `exclude_search` to true in page metadata. 
Another approach is to modify the range from `.Site.AllPages` to `.Site.RegularPages` in offline-search-index.json. This, however, involves changes in docsy, so I did't go for it.